### PR TITLE
라운드 수 계산 방식 수정

### DIFF
--- a/src/hooks/candidates.js
+++ b/src/hooks/candidates.js
@@ -94,7 +94,7 @@ const CandidatesProvider = ({ children }) => {
   const [round, setRound] = useState(0)
   const [showResult, setShowResult] = useState(false)
 
-  const totalRounds = candidates.length
+  const totalRounds = Math.log(candidates.length) / Math.log(2)
   const totalSteps = totalRounds / 2
   const isGameEnded = round === totalRounds
 


### PR DESCRIPTION
현재 라운드 수를 사진 수로 계산하고 있어서 `Math.log(candidates.length) / Math.log(2)` 방식으로 수정합니다.