### PR TITLE
종료 라운드 판단 기준 수정

### DIFF
--- a/src/hooks/candidates.js
+++ b/src/hooks/candidates.js
@@ -96,7 +96,7 @@ const CandidatesProvider = ({ children }) => {
 
   const totalRounds = Math.log(16) / Math.log(2)
   const totalSteps = candidates.length / 2
-  const isGameEnded = round === totalRounds
+  const isGameEnded = round === (totalRounds - 1)
 
   return (
     <CandidatesContext.Provider


### PR DESCRIPTION
사진이 16장인 현재 `isGameEnded` 변수는 `round === 4`일 때 `true`가 되는데(0, 1, 2, 3, 4로 총 5개 라운드 진행됨) 실제로는 16강, 8강, 4강, 결승의 4개 라운드가 진행되어야 하므로 `round === 4 - 1`일 때를 확인하도록 수정합니다.